### PR TITLE
Minuten-LEDs zeilenweise

### DIFF
--- a/Qlockthree.ino
+++ b/Qlockthree.ino
@@ -1608,7 +1608,7 @@ void hourPlusPressed() {
       break;
 #ifdef USE_EXT_MODE_CORNERS
     case EXT_MODE_CORNERS:
-      settings.setRenderCornersMode(!settings.getRenderCornersMode());
+      settings.setRenderCornersMode((settings.getRenderCornersMode() + 1) % 4);
       break;
 #endif
 #ifdef ALARM

--- a/Qlockthree.ino
+++ b/Qlockthree.ino
@@ -907,7 +907,7 @@ void loop() {
       case EXT_MODE_TIMESET:
         renderer.clearScreenBuffer(matrix);
         renderer.setMinutes(rtc.getHours() + settings.getTimeShift(), rtc.getMinutes(), settings.getLanguage(), matrix);
-        renderer.setCorners(rtc.getMinutes(), settings.getRenderCornersCw(), matrix);
+        renderer.setCorners(rtc.getMinutes(), settings.getRenderCornersMode(), matrix);
         break;
 #ifdef USE_EXT_MODE_TIME_SHIFT
       case EXT_MODE_TIME_SHIFT:
@@ -937,11 +937,11 @@ void loop() {
         renderer.clearScreenBuffer(matrix);
         if (alarm.getShowAlarmTimeTimer() == 0) {
           renderer.setMinutes(rtc.getHours() + settings.getTimeShift(), rtc.getMinutes(), settings.getLanguage(), matrix);
-          renderer.setCorners(rtc.getMinutes(), settings.getRenderCornersCw(), matrix);
+          renderer.setCorners(rtc.getMinutes(), settings.getRenderCornersMode(), matrix);
           renderer.activateAlarmLed(matrix); // Alarm-LED
         } else {
           renderer.setMinutes(alarm.getHours() + settings.getTimeShift(), alarm.getMinutes(), settings.getLanguage(), matrix);
-          renderer.setCorners(alarm.getMinutes(), settings.getRenderCornersCw(), matrix);
+          renderer.setCorners(alarm.getMinutes(), settings.getRenderCornersMode(), matrix);
           renderer.cleanWordsForAlarmSettingMode(settings.getLanguage(), matrix); // ES IST weg
           if (alarm.getShowAlarmTimeTimer() % 2 == 0) {
             renderer.activateAlarmLed(matrix); // Alarm-LED
@@ -1000,11 +1000,22 @@ void loop() {
 #ifdef USE_EXT_MODE_CORNERS
       case EXT_MODE_CORNERS:
         renderer.clearScreenBuffer(matrix);
-        if (settings.getRenderCornersCw()) {
+        switch(settings.getRenderCornersMode()) {
+          case 0:
           renderer.setMenuText("CW", Renderer::TEXT_POS_MIDDLE, matrix);
-        } else {
+          break;
+          case 1:
           renderer.setMenuText("C", Renderer::TEXT_POS_TOP, matrix);
           renderer.setMenuText("CW", Renderer::TEXT_POS_BOTTOM, matrix);
+          break;
+          case 2:
+          renderer.setMenuText("C", Renderer::TEXT_POS_TOP, matrix);
+          renderer.setMenuText("LW", Renderer::TEXT_POS_BOTTOM, matrix);
+          break;
+          case 3:
+          renderer.setMenuText("C", Renderer::TEXT_POS_TOP, matrix);
+          renderer.setMenuText("LW", Renderer::TEXT_POS_BOTTOM, matrix);
+          break;
         }
         break;
 #endif
@@ -1116,7 +1127,7 @@ void loop() {
           renderer.setMinutes(settings.getNightModeTime(false)->getHours(), settings.getNightModeTime(false)->getMinutes(), settings.getLanguage(), matrix);
           renderer.cleanWordsForAlarmSettingMode(settings.getLanguage(), matrix); // ES IST weg
           if ( (settings.getNightModeTime(false)->getHours() >= 12) ) {
-            renderer.setCorners(1, settings.getRenderCornersCw(), matrix);
+            renderer.setCorners(1, settings.getRenderCornersMode(), matrix);
           }
         }
         break;
@@ -1132,7 +1143,7 @@ void loop() {
           renderer.setMinutes(settings.getNightModeTime(true)->getHours(), settings.getNightModeTime(true)->getMinutes(), settings.getLanguage(), matrix);
           renderer.cleanWordsForAlarmSettingMode(settings.getLanguage(), matrix); // ES IST weg
           if ( (settings.getNightModeTime(true)->getHours() >= 12) ) {
-            renderer.setCorners(1, settings.getRenderCornersCw(), matrix);
+            renderer.setCorners(1, settings.getRenderCornersMode(), matrix);
           }
         }
         break;
@@ -1208,7 +1219,7 @@ void loop() {
 #ifdef USE_EXT_MODE_TEST
       case EXT_MODE_TEST:
         renderer.clearScreenBuffer(matrix);
-        renderer.setCorners(helperSeconds % 5, settings.getRenderCornersCw(), matrix);
+        renderer.setCorners(helperSeconds % 5, settings.getRenderCornersMode(), matrix);
 #ifdef ALARM
         if (settings.getEnableAlarm()) {
           renderer.activateAlarmLed(matrix); // Alarm-LED
@@ -1242,7 +1253,7 @@ void loop() {
 #ifdef USE_EXT_MODE_DCF_DEBUG
       case EXT_MODE_DCF_DEBUG:
         renderer.clearScreenBuffer(matrix);
-        renderer.setCorners(dcf77.getDcf77ErrorCorner(), settings.getRenderCornersCw(), matrix);
+        renderer.setCorners(dcf77.getDcf77ErrorCorner(), settings.getRenderCornersMode(), matrix);
         break;
 #endif
       default:
@@ -1597,7 +1608,7 @@ void hourPlusPressed() {
       break;
 #ifdef USE_EXT_MODE_CORNERS
     case EXT_MODE_CORNERS:
-      settings.setRenderCornersCw(!settings.getRenderCornersCw());
+      settings.setRenderCornersMode(!settings.getRenderCornersMode());
       break;
 #endif
 #ifdef ALARM
@@ -1722,7 +1733,7 @@ void minutePlusPressed() {
       break;
 #ifdef USE_EXT_MODE_CORNERS
     case EXT_MODE_CORNERS:
-      settings.setRenderCornersCw(!settings.getRenderCornersCw());
+      settings.setRenderCornersMode((settings.getRenderCornersMode() + 1) % 4);
       break;
 #endif
 #ifdef ALARM

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -1177,16 +1177,41 @@ void Renderer::setHours(byte hours, boolean glatt, byte language, word matrix[16
 /**
    Im Alarm-Einstell-Modus muessen bestimmte Woerter weg, wie z.B. "ES IST" im Deutschen.
 */
-void Renderer::setCorners(byte minutes, boolean cw, word matrix[16]) {
+void Renderer::setCorners(byte minutes, byte mode, word matrix[16]) {
     byte b_minutes = minutes % 5;
     for (byte i = 0; i < b_minutes; i++) {
         byte j;
-        if (cw) {
-          // j: 1, 0, 3, 2
+        switch(mode) {
+          case 0: // CW; j: 1, 0, 3, 2
           j = (1 - i + 4) % 4;
-        } else {
-          // j: 0, 1, 2, 3
+          break;
+          case 1: // CCW; j: 0, 1, 2, 3
           j = i;
+          break;
+          case 2: // LW; j: 0, 1, 3, 2
+          switch(j) {
+            case 0:
+            case 1:
+            j = i;
+            break;
+            case 2:
+            case 3:
+            j = (1 - i + 4) % 4;
+            break;
+          }
+          break;
+          case 3: // CLW: j: 1, 0, 2, 3
+          switch(j) {
+            case 0:
+            case 1:
+            j = (1 - i + 4) % 4;
+            break;
+            case 2:
+            case 3:
+            j = i;
+            break;
+          }
+          break;
         }
         #ifdef USE_INDIVIDUAL_CATHODES
             matrix[j] |= (0b0000000000010000 >> j);

--- a/Renderer.h
+++ b/Renderer.h
@@ -63,7 +63,7 @@ class Renderer {
     Renderer();
 
     void setMinutes(char hours, byte minutes, byte language, word matrix[16]);
-    void setCorners(byte minutes, boolean cw, word matrix[16]);
+    void setCorners(byte minutes, byte mode, word matrix[16]);
     void activateAlarmLed(word matrix[16]);
 
     void cleanWordsForAlarmSettingMode(byte language, word matrix[16]);

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -45,7 +45,7 @@ Settings::Settings() {
 void Settings::resetToDefault() {
   _language = 0; //erste Sprache in Renderer::eLanguage
   _event = 0;
-  _renderCornersCw = true;
+  _renderCornersMode = 0;
   _use_ldr = true;
   _brightness = 75;
   _enableAlarm = false;
@@ -84,12 +84,12 @@ void Settings::setEvent(byte event) {
 /**
  * Die Laufrichtung der Eck-LEDs.
  */
-boolean Settings::getRenderCornersCw() {
-  return _renderCornersCw;
+boolean Settings::getRenderCornersMode() {
+  return _renderCornersMode;
 }
 
-void Settings::setRenderCornersCw(boolean cw) {
-  _renderCornersCw = cw;
+void Settings::setRenderCornersMode(byte mode) {
+  _renderCornersMode = mode;
 }
 
 /**
@@ -198,7 +198,7 @@ void Settings::loadFromEEPROM() {
     if (EEPROM.read(2) < LANGUAGE_COUNT){
     _language = EEPROM.read(2);
     }
-    _renderCornersCw = EEPROM.read(3);
+    _renderCornersMode = EEPROM.read(3);
     _use_ldr = EEPROM.read(4);
     _brightness = EEPROM.read(5);
     _enableAlarm = EEPROM.read(6);
@@ -227,8 +227,8 @@ void Settings::saveToEEPROM() {
   if (EEPROM.read(2) != _language) {
     EEPROM.write(2, _language);
   }
-  if (EEPROM.read(3) != _renderCornersCw) {
-    EEPROM.write(3, _renderCornersCw);
+  if (EEPROM.read(3) != _renderCornersMode) {
+    EEPROM.write(3, _renderCornersMode);
   }
   if (EEPROM.read(4) != _use_ldr) {
     EEPROM.write(4, _use_ldr);

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -84,7 +84,7 @@ void Settings::setEvent(byte event) {
 /**
  * Die Laufrichtung der Eck-LEDs.
  */
-boolean Settings::getRenderCornersMode() {
+byte Settings::getRenderCornersMode() {
   return _renderCornersMode;
 }
 

--- a/Settings.h
+++ b/Settings.h
@@ -44,7 +44,7 @@ class Settings {
     byte getEvent();
     void setEvent(byte event);
 
-    boolean getRenderCornersMode();
+    byte getRenderCornersMode();
     void setRenderCornersMode(byte mode);
 
     boolean getUseLdr();

--- a/Settings.h
+++ b/Settings.h
@@ -44,8 +44,8 @@ class Settings {
     byte getEvent();
     void setEvent(byte event);
 
-    boolean getRenderCornersCw();
-    void setRenderCornersCw(boolean cw);
+    boolean getRenderCornersMode();
+    void setRenderCornersMode(byte mode);
 
     boolean getUseLdr();
     void setUseLdr(boolean useLdr);
@@ -83,7 +83,7 @@ class Settings {
 
   private:
     byte _language;
-    boolean _renderCornersCw;
+    byte _renderCornersMode;
     boolean _use_ldr;
     byte _brightness;
     boolean _enableAlarm;


### PR DESCRIPTION
Alternativer Modus (über das Menü konfigurierbar), in dem die Minuten-LEDs zeilenweise ("LW", links oben, rechts oben, links unten, rechts unten) bzw. anti-zeilenweise ("CLW") angezeigt werden.
